### PR TITLE
Fix - Exclude non-PC party members from default XP Award destination

### DIFF
--- a/pf2e-awardxp.js
+++ b/pf2e-awardxp.js
@@ -149,7 +149,7 @@ class Award extends FormApplication {
         const context = super.getData(options);
         context.xp = this.options.xp ?? 0;
         context.description = this.options.description ?? null;
-        context.destinations = this.options.destinations.length > 0 ? this.options.destinations : game.actors.party.members;
+        context.destinations = this.options.destinations.length > 0 ? this.options.destinations : game.actors.party.members.filter(m => m.type === "character");
         return context;
       }
 


### PR DESCRIPTION
When Awarding XP outside of combat, non-player character actors (e.g. Familiars) might be in the "party" but are not valid targets to be awarded XP. These invalid XP targets are included by default for the XP award dialog, as long as they're in the party.

This is a simple fix to ensure that, by default, only "character" actor types (player characters) are included in the default target list.